### PR TITLE
Support for PAN11 Power seitch with energy meter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,8 @@ proguard/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-#exlipse
+#eclipse
 .classpath
 .project
 .settings
 target
-

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ proguard/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+#exlipse
+.classpath
+.project
+.settings
+target
+

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mapdb</groupId>
+            <artifactId>mapdb</artifactId>
+            <version>1.0.9</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/whizzosoftware/wzwave/node/specific/BinaryPowerSwitch.java
+++ b/src/main/java/com/whizzosoftware/wzwave/node/specific/BinaryPowerSwitch.java
@@ -7,8 +7,11 @@
  *******************************************************************************/
 package com.whizzosoftware.wzwave.node.specific;
 
+import com.whizzosoftware.wzwave.commandclass.MeterCommandClass;
+import com.whizzosoftware.wzwave.commandclass.MultilevelSensorCommandClass;
 import com.whizzosoftware.wzwave.node.NodeInfo;
 import com.whizzosoftware.wzwave.node.NodeListener;
+import com.whizzosoftware.wzwave.node.ZWaveEndpoint;
 import com.whizzosoftware.wzwave.node.generic.BinarySwitch;
 import com.whizzosoftware.wzwave.persist.PersistenceContext;
 
@@ -22,9 +25,20 @@ public class BinaryPowerSwitch extends BinarySwitch {
 
     public BinaryPowerSwitch(NodeInfo info, boolean listening, NodeListener listener) {
         super(info, listening, listener);
+        addCommandClass(MeterCommandClass.ID, new MeterCommandClass());
+        addCommandClass(MultilevelSensorCommandClass.ID, new MultilevelSensorCommandClass());
     }
 
     public BinaryPowerSwitch(PersistenceContext pctx, Byte nodeId, NodeListener listener) {
         super(pctx, nodeId, listener);
+    }
+
+    static public Double getCurrentValue(ZWaveEndpoint endpoint) {
+        MeterCommandClass cc = (MeterCommandClass) endpoint.getCommandClass(MeterCommandClass.ID);
+        if (cc != null) {
+            return cc.getCurrentValue();
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/whizzosoftware/wzwave/node/specific/BinaryPowerSwitch.java
+++ b/src/main/java/com/whizzosoftware/wzwave/node/specific/BinaryPowerSwitch.java
@@ -25,20 +25,9 @@ public class BinaryPowerSwitch extends BinarySwitch {
 
     public BinaryPowerSwitch(NodeInfo info, boolean listening, NodeListener listener) {
         super(info, listening, listener);
-        addCommandClass(MeterCommandClass.ID, new MeterCommandClass());
-        addCommandClass(MultilevelSensorCommandClass.ID, new MultilevelSensorCommandClass());
     }
 
     public BinaryPowerSwitch(PersistenceContext pctx, Byte nodeId, NodeListener listener) {
         super(pctx, nodeId, listener);
-    }
-
-    static public Double getCurrentValue(ZWaveEndpoint endpoint) {
-        MeterCommandClass cc = (MeterCommandClass) endpoint.getCommandClass(MeterCommandClass.ID);
-        if (cc != null) {
-            return cc.getCurrentValue();
-        } else {
-            return null;
-        }
     }
 }

--- a/src/main/java/com/whizzosoftware/wzwave/product/ProductRegistry.java
+++ b/src/main/java/com/whizzosoftware/wzwave/product/ProductRegistry.java
@@ -18,10 +18,13 @@ import org.slf4j.LoggerFactory;
 public class ProductRegistry {
     private static final Logger logger = LoggerFactory.getLogger(ProductRegistry.class);
 
+    // Find info here: http://www.cd-jackson.com/index.php/zwave/zwave-device-database/zwave-device-list
+    public final static String M_PHILIO = "Philio Technology Corporation ";
     public final static String M_AEON_LABS = "Aeon Labs";
     public final static String M_EVERSPRING = "Everspring";
     public final static String M_GE_JASCO = "GE/Jasco";
 
+    public final static String P_PAN11 = "Smart Energy Plug In Switch (PAN11)";
     public final static String P_45604_OUTDOOR_MODULE = "45604 Outdoor Module";
     public final static String P_45609_RELAY_SWITCH = "45609 On/Off Relay Switch";
     public final static String P_45612_DIMMER_SWITCH = "45612 Dimmer Switch";
@@ -114,6 +117,19 @@ public class ProductRegistry {
                 }
                 break;
 
+            // Philio
+            case 316:
+                info.setManufacturer(M_PHILIO);
+                switch (ptid) {
+                    case 1:
+                        switch (pid) {
+                            case 17:
+                                info.setName(P_PAN11);
+                                break;
+                        }
+                        break;
+                }
+
             default:
                 break;
         }
@@ -121,7 +137,7 @@ public class ProductRegistry {
         if (!info.isComplete() && manufacturerId != null && productTypeId != null && productId != null) {
             logger.error("You are using a product that is not in WZWave's product registry. If the product is " +
                     "working properly with WZWave, please submit the following to the project so it can be " +
-                    "added to the registry: {},{},{}", manufacturerId, productTypeId, productId);
+                    "added to the registry: Resolved {} from Manufacturer: {}, Product Type: {}, Product Id:{}", info, manufacturerId, productTypeId, productId);
         }
 
         return info;


### PR DESCRIPTION
Quite new to ZWave and WZWave, but managed to get my switch with meter running.
According to some docs I found it was a multilevelsensor and a meter, so adding those commandclasses to BinaryPowerSwitch.
It works for me and my device, but not sure if all Binary Power Switches are Meters ?
