### PR TITLE
Switch from Rxtx to jSerialComm serial library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,15 +66,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-rxtx</artifactId>
-            <version>4.0.21.Final</version>
+            <groupId>se.koc</groupId>
+            <artifactId>netty-transport-jserialcomm</artifactId>
+            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.rxtx</groupId>
-            <artifactId>rxtx</artifactId>
-            <version>2.1.7</version>
+            <groupId>com.fazecast</groupId>
+            <artifactId>jSerialComm</artifactId>
+            <version>1.3.11</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/whizzosoftware/wzwave/controller/netty/NettyZWaveController.java
+++ b/src/main/java/com/whizzosoftware/wzwave/controller/netty/NettyZWaveController.java
@@ -29,9 +29,9 @@ import com.whizzosoftware.wzwave.util.ByteUtil;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
 import io.netty.channel.oio.OioEventLoopGroup;
-import io.netty.channel.rxtx.RxtxChannel;
-import io.netty.channel.rxtx.RxtxChannelConfig;
-import io.netty.channel.rxtx.RxtxDeviceAddress;
+import io.netty.channel.jsc.JSerialCommChannel;
+import io.netty.channel.jsc.JSerialCommChannelConfig;
+import io.netty.channel.jsc.JSerialCommDeviceAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,15 +158,15 @@ public class NettyZWaveController implements ZWaveController, ZWaveControllerCon
             Bootstrap bootstrap = new Bootstrap();
             eventLoopGroup = new OioEventLoopGroup();
             bootstrap.group(eventLoopGroup);
-            bootstrap.channel(RxtxChannel.class);
-            bootstrap.handler(new ChannelInitializer<RxtxChannel>() {
+            bootstrap.channel(JSerialCommChannel.class);
+            bootstrap.handler(new ChannelInitializer<JSerialCommChannel>() {
                 @Override
-                protected void initChannel(RxtxChannel channel) throws Exception {
+                protected void initChannel(JSerialCommChannel channel) throws Exception {
                     NettyZWaveController.this.channel = channel;
                     channel.config().setBaudrate(115200);
-                    channel.config().setDatabits(RxtxChannelConfig.Databits.DATABITS_8);
-                    channel.config().setParitybit(RxtxChannelConfig.Paritybit.NONE);
-                    channel.config().setStopbits(RxtxChannelConfig.Stopbits.STOPBITS_1);
+                    channel.config().setDatabits(8);
+                    channel.config().setParitybit(JSerialCommChannelConfig.Paritybit.NONE);
+                    channel.config().setStopbits(JSerialCommChannelConfig.Stopbits.STOPBITS_1);
                     channel.pipeline().addLast("decoder", new ZWaveFrameDecoder());
                     channel.pipeline().addLast("ack", new ACKInboundHandler());
                     channel.pipeline().addLast("encoder", new ZWaveFrameEncoder());
@@ -176,7 +176,7 @@ public class NettyZWaveController implements ZWaveController, ZWaveControllerCon
                 }
             });
 
-            bootstrap.connect(new RxtxDeviceAddress(serialPort)).addListener(new ChannelFutureListener() {
+            bootstrap.connect(new JSerialCommDeviceAddress(serialPort)).addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
                     if (future.isSuccess()) {


### PR DESCRIPTION
As Netty is about to deprecate Rxtx it probably is a good time to start moving over to the jSerialComm library.

One of the main benefits of jSerialComm is that it does not require any installation of binaries to function properly, it handles this automatically.

This PR is related to issue #11