### PR TITLE
Poll instead of Remove on Protocol Info Queue

### DIFF
--- a/src/main/java/com/whizzosoftware/wzwave/channel/ZWaveChannelInboundHandler.java
+++ b/src/main/java/com/whizzosoftware/wzwave/channel/ZWaveChannelInboundHandler.java
@@ -112,7 +112,7 @@ public class ZWaveChannelInboundHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void processNodeProtocolInfo(NodeProtocolInfo nodeProtocolInfo) {
-        Byte nodeId = nodeProtocolInfoQueue.remove();
+        Byte nodeId = nodeProtocolInfoQueue.poll();
         if (nodeId != null) {
             listener.onNodeProtocolInfo(nodeId, nodeProtocolInfo);
         } else {


### PR DESCRIPTION
Call poll() instead of remove() on Queue to avoid NoSuchElementException.

Closes #33